### PR TITLE
chore: rename project to commerce_helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@
 
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in address_helper.gemspec
+# Specify your gem's dependencies in commerce_helpers.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# AddressHelper [![CircleCI][badge]][circleci]
+# CommerceHelpers [![CircleCI][badge]][circleci]
 
-AddressHelper is a library to provide address-related helpers and data. It is built as a Ruby gem and Node package, and
+CommerceHelpers is a library to provide address-related helpers and data. It is built as a Ruby gem and Node package, and
 aims to share things across stacks.
 
 ## Installation and Usage
@@ -10,29 +10,29 @@ aims to share things across stacks.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'address_helper', git: 'https://github.com/artsy/address_helper.git', branch: 'main'
+gem 'commerce_helpers', git: 'https://github.com/artsy/commerce_helpers.git', branch: 'main'
 ```
 
 And execute:
 
     bundle install
 
-Then it can be accessed through the `AddressHelper` module, for example:
+Then it can be accessed through the `CommerceHelpers` module, for example:
 
 ```ruby
-AddressHelper::COUNTRIES_IN_CONTINENTAL_EUROPE
+CommerceHelpers::COUNTRIES_IN_CONTINENTAL_EUROPE
 ```
 
 ### As a Node package
 
 Run:
 
-    yarn add artsy/address_helper
+    yarn add artsy/commerce_helpers
 
 Then it can be accessed as:
 
 ```javascript
-import { COUNTRIES_IN_CONTINENTAL_EUROPE } from "@artsy/address_helper"
+import { COUNTRIES_IN_CONTINENTAL_EUROPE } from "@artsy/commerce_helpers"
 ```
 
 ## Development
@@ -50,10 +50,10 @@ The gem is available as open source under the terms of the [MIT License][license
 
 ## Code of Conduct
 
-Everyone interacting in the AddressHelper project's codebases, issue trackers, chat rooms and mailing lists is expected
+Everyone interacting in the CommerceHelpers project's codebases, issue trackers, chat rooms and mailing lists is expected
 to follow the [code of conduct][code_of_conduct].
 
-[badge]: https://circleci.com/gh/artsy/address_helper/tree/main.svg?style=shield
-[circleci]: https://circleci.com/gh/artsy/address_helper/tree/main
-[code_of_conduct]: https://github.com/artsy/address_helper/blob/main/CODE_OF_CONDUCT.md
+[badge]: https://circleci.com/gh/artsy/commerce_helpers/tree/main.svg?style=shield
+[circleci]: https://circleci.com/gh/artsy/commerce_helpers/tree/main
+[code_of_conduct]: https://github.com/artsy/commerce_helpers/blob/main/CODE_OF_CONDUCT.md
 [license]: https://opensource.org/licenses/MIT

--- a/bin/check_data_drift.sh
+++ b/bin/check_data_drift.sh
@@ -10,9 +10,9 @@ MSG_CLEAN="\n${GREEN}Ruby and JSON data are consistent.${NO_COLOR}"
 MSG_DRIFT="\n${RED}Ruby and JSON data are out-of-sync. If you updated the Ruby data, consider
 regenerating the JSON with the rake task and committing the change:
 
-    bundle exec rake address_helper:generate_data${NO_COLOR}"
+    bundle exec rake commerce_helpers:generate_data${NO_COLOR}"
 
-bundle exec rake address_helper:generate_data
+bundle exec rake commerce_helpers:generate_data
 
 if [ -z "$(git status --porcelain)" ]; then
   echo "$MSG_CLEAN"

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'address_helper'
+require 'commerce_helpers'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/commerce_helpers.gemspec
+++ b/commerce_helpers.gemspec
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-require_relative 'lib/address_helper/version'
+require_relative 'lib/commerce_helpers/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'address_helper'
-  spec.version       = AddressHelper::VERSION
+  spec.name          = 'commerce_helpers'
+  spec.version       = CommerceHelpers::VERSION
   spec.authors       = ['Chung-Yi Chi']
   spec.email         = ['chung-yi@artsymail.com']
 
-  spec.summary       = 'Address handling utility'
-  spec.description   = 'A simple module for handling addresses and co-locating address data'
-  spec.homepage      = 'https://github.com/artsy/address_helper'
+  spec.summary       = 'Helpers for handling common commerce tasks'
+  spec.description   = 'A simple module for handling commerce-related tasks and data'
+  spec.homepage      = 'https://github.com/artsy/commerce_helpers'
   spec.license       = 'MIT'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
 

--- a/lib/commerce_helpers.rb
+++ b/lib/commerce_helpers.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'address_helper/version'
+require 'commerce_helpers/version'
 
-module AddressHelper
+module CommerceHelpers
   COUNTRIES_REQUIRING_VAT = %w[AE AT BE BG CH CZ DE DK EE ES FI FR GB GR HU IE IT LT LU LV MT MX NL NO PL PT RO SE SI
                                SK].freeze
   COUNTRIES_IN_CONTINENTAL_EUROPE = %w[AD AM AT AZ BA BE BG BY CH CY CZ DE DK EE ES FI FR GE HR HU IT KZ LI LT LU LV MC

--- a/lib/commerce_helpers/version.rb
+++ b/lib/commerce_helpers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module AddressHelper
+module CommerceHelpers
   VERSION = '0.1.0'
 end

--- a/lib/tasks/generate_data.rake
+++ b/lib/tasks/generate_data.rake
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'address_helper'
+require 'commerce_helpers'
 
-namespace :address_helper do
+namespace :commerce_helpers do
   desc 'Generate data in a JSON file'
   task :generate_data do
     File.open('package/data/data.json', 'w') do |f|
       data = {
-        COUNTRIES_REQUIRING_VAT: AddressHelper::COUNTRIES_REQUIRING_VAT,
-        COUNTRIES_IN_CONTINENTAL_EUROPE: AddressHelper::COUNTRIES_IN_CONTINENTAL_EUROPE
+        COUNTRIES_REQUIRING_VAT: CommerceHelpers::COUNTRIES_REQUIRING_VAT,
+        COUNTRIES_IN_CONTINENTAL_EUROPE: CommerceHelpers::COUNTRIES_IN_CONTINENTAL_EUROPE
       }
 
       f.write(JSON.pretty_generate(data))

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@artsy/address_helper",
+  "name": "@artsy/commerce_helpers",
   "version": "0.1.0",
-  "description": "A simple module for handling addresses and co-locating address data",
+  "description": "A simple module for handling commerce-related tasks and data",
   "main": "package/index.js",
-  "repository": "https://github.com/artsy/address_helper.git",
+  "repository": "https://github.com/artsy/commerce_helpers.git",
   "author": "Chung-Yi Chi <chung-yi@artsymail.com>",
   "license": "MIT"
 }

--- a/spec/commerce_helpers_spec.rb
+++ b/spec/commerce_helpers_spec.rb
@@ -2,13 +2,13 @@
 
 require 'countries'
 
-RSpec.describe AddressHelper do
+RSpec.describe CommerceHelpers do
   it 'has a version number' do
-    expect(AddressHelper::VERSION).not_to be nil
+    expect(CommerceHelpers::VERSION).not_to be nil
   end
 
   it 'has a list of countries requiring VAT' do
-    expect(AddressHelper::COUNTRIES_REQUIRING_VAT).to match_array(
+    expect(CommerceHelpers::COUNTRIES_REQUIRING_VAT).to match_array(
       [
         'Austria',
         'Belgium',
@@ -47,6 +47,6 @@ RSpec.describe AddressHelper do
   end
 
   it 'has a list of countries in continental Europe' do
-    expect(AddressHelper::COUNTRIES_IN_CONTINENTAL_EUROPE).not_to be_empty
+    expect(CommerceHelpers::COUNTRIES_IN_CONTINENTAL_EUROPE).not_to be_empty
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'address_helper'
+require 'commerce_helpers'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
See [Slack thread](https://artsy.slack.com/archives/C9YNS4X32/p1654524157307419) for discussion.

We want to rename the library to include more shareable data/logic beyond just the addresses. Using a single repo allows us to simplify dev workflow without dealing with multiple repos, and we think "commerce" is a good scope to be broad enough and still focused.

To preserve the history better, I ended up renaming this GH project to commerce_helpers and pushed the current address_helper to [a newly created project](https://github.com/artsy/address_helper) (so existing clients can still install it the same way).