### PR TITLE
feat: add COUNTRIES_WITH_SEPA

### DIFF
--- a/lib/commerce_helpers.rb
+++ b/lib/commerce_helpers.rb
@@ -11,6 +11,8 @@ module CommerceHelpers
                                 .freeze
   COUNTRIES_WITH_ARTSY_SHIPPING = %w[US GB CH NO] + COUNTRIES_IN_EUROPEAN_UNION
                                   .freeze
+  COUNTRIES_WITH_SEPA = %w[AU CA GI HK JP LI MX NZ NO SG CH GB US] + COUNTRIES_IN_EUROPEAN_UNION
+                        .freeze
 
   CURRENCIES_SUPPORTED_IN_COMMERCE = %w[EUR GBP USD].freeze
 end

--- a/lib/commerce_helpers/version.rb
+++ b/lib/commerce_helpers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CommerceHelpers
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/commerce_helpers_spec.rb
+++ b/spec/commerce_helpers_spec.rb
@@ -126,6 +126,55 @@ RSpec.describe CommerceHelpers do
     )
   end
 
+  it 'has a list of countries that are supported by Stripe SEPA' do
+    expect(CommerceHelpers::COUNTRIES_WITH_SEPA).to match_array(
+      [
+        'Australia',
+        'Canada',
+        'Gibraltar',
+        'Hong Kong',
+        'Japan',
+        'Liechtenstein',
+        'Mexico',
+        'New Zealand',
+        'Norway',
+        'Singapore',
+        'Switzerland',
+        'United Kingdom of Great Britain and Northern Ireland',
+        'United States of America',
+        'Austria',
+        'Belgium',
+        'Bulgaria',
+        'Cyprus',
+        'Czechia',
+        'Germany',
+        'Denmark',
+        'Estonia',
+        'Spain',
+        'Finland',
+        'France',
+        'Greece',
+        'Croatia',
+        'Hungary',
+        'Ireland',
+        'Italy',
+        'Lithuania',
+        'Luxembourg',
+        'Latvia',
+        'Malta',
+        'Netherlands',
+        'Poland',
+        'Portugal',
+        'Romania',
+        'Sweden',
+        'Slovenia',
+        'Slovakia'
+      ].map do |name|
+        ISO3166::Country.find_country_by_iso_short_name(name).alpha2
+      end
+    )
+  end
+
   it 'has a list of currencies supported in commerce transactions' do
     expect(CommerceHelpers::CURRENCIES_SUPPORTED_IN_COMMERCE).to match_array(
       %w[EUR GBP USD]


### PR DESCRIPTION
Add the list of countries where SEPA is supported. We will need this in Exchange to be able to enable SEPA.

https://artsyproduct.atlassian.net/browse/TX-530

![Screenshot 2022-08-26 at 09 33 52](https://user-images.githubusercontent.com/554507/186848337-4f1447be-730c-4185-b0af-98ea6187dd9e.png)

https://stripe.com/docs/payments/sepa-debit